### PR TITLE
Update `HasContent::class`, no encode stringable content.

### DIFF
--- a/src/Attribute/Custom/HasContent.php
+++ b/src/Attribute/Custom/HasContent.php
@@ -22,7 +22,7 @@ trait HasContent
      */
     public function content(string|Stringable $value, bool $encode = true): static
     {
-        if ($encode) {
+        if (!$value instanceof Stringable && $encode) {
             $value = Encode::content($value);
         }
 

--- a/tests/Attribute/Custom/HasContentTest.php
+++ b/tests/Attribute/Custom/HasContentTest.php
@@ -39,6 +39,31 @@ final class HasContentTest extends TestCase
         $this->assertNotSame($instance, $instance->content(''));
     }
 
+    public function testStringable(): void
+    {
+        $instance = new class () {
+            use HasContent;
+
+            protected array $attributes = [];
+
+            public function getContent(): string
+            {
+                return $this->content;
+            }
+        };
+
+        $instance = $instance->content(
+            new class () implements Stringable {
+                public function __toString(): string
+                {
+                    return 'foo && bar';
+                }
+            },
+        );
+
+        $this->assertSame('foo && bar', $instance->getContent());
+    }
+
     public function testStringableWithEncodeFalse(): void
     {
         $instance = new class () {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
