### PR TITLE
Add method `cleanXSS()` to `Encode::class` helper.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "ext-dom": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",
-        "php-forge/awesome-widget": "^1.0@dev"
+        "php-forge/awesome-widget": "^1.0@dev",
+        "voku/anti-xss": "^4.1"
     },
     "require-dev": {
         "maglnet/composer-require-checker": "^4.3",

--- a/src/Attribute/Custom/HasContent.php
+++ b/src/Attribute/Custom/HasContent.php
@@ -28,10 +28,9 @@ trait HasContent
                 $value = $value->render();
             }
 
-            $new->content .= match (Encode::isValidTag($value)) {
-                true => $value,
-                false => Encode::content($value),
-            };
+            /** @psalm-var string|string[] */
+            $cleanContent = Encode::cleanXSS($value);
+            $new->content .= is_array($cleanContent) ? implode('', $cleanContent) : $cleanContent;
         }
 
         return $new;

--- a/src/Attribute/Custom/HasLabel.php
+++ b/src/Attribute/Custom/HasLabel.php
@@ -74,10 +74,9 @@ trait HasLabel
                 $value = $value->render();
             }
 
-            $new->labelContent .= match (Encode::isValidTag($value)) {
-                true => $value,
-                false => Encode::content($value),
-            };
+            /** @psalm-var string|string[] */
+            $cleanContent = Encode::cleanXSS($value);
+            $new->labelContent .= is_array($cleanContent) ? implode('', $cleanContent) : $cleanContent;
         }
 
         return $new;

--- a/src/Attribute/Custom/HasPrefixAndSuffix.php
+++ b/src/Attribute/Custom/HasPrefixAndSuffix.php
@@ -29,10 +29,7 @@ trait HasPrefixAndSuffix
                 $value = $value->render();
             }
 
-            $new->prefix .= match (Encode::isValidTag($value)) {
-                true => $value,
-                false => Encode::content($value),
-            };
+            $new->prefix .= Encode::cleanXSS($value);
         }
 
         return $new;
@@ -50,10 +47,7 @@ trait HasPrefixAndSuffix
                 $value = $value->render();
             }
 
-            $new->suffix .= match (Encode::isValidTag($value)) {
-                true => $value,
-                false => Encode::content($value),
-            };
+            $new->suffix .= Encode::cleanXSS($value);
         }
 
         return $new;

--- a/src/Attribute/Custom/HasPrefixAndSuffixItems.php
+++ b/src/Attribute/Custom/HasPrefixAndSuffixItems.php
@@ -29,10 +29,7 @@ trait HasPrefixAndSuffixItems
                 $value = $value->render();
             }
 
-            $new->prefixItems .= match (Encode::isValidTag($value)) {
-                true => $value,
-                false => Encode::content($value),
-            };
+            $new->prefixItems .= Encode::cleanXSS($value);
         }
 
         return $new;
@@ -50,10 +47,7 @@ trait HasPrefixAndSuffixItems
                 $value = $value->render();
             }
 
-            $new->suffixItems .= match (Encode::isValidTag($value)) {
-                true => $value,
-                false => Encode::content($value),
-            };
+            $new->suffixItems .= Encode::cleanXSS($value);
         }
 
         return $new;

--- a/src/Helper/Encode.php
+++ b/src/Helper/Encode.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace PHPForge\Html\Helper;
 
-use DOMDocument;
+use voku\helper\AntiXSS;
 
 use function htmlspecialchars;
-use function libxml_get_errors;
-use function libxml_use_internal_errors;
 use function strtr;
 
 /**
@@ -57,32 +55,10 @@ final class Encode
         return strtr($value, ['\u{0000}' => '&#0;']); // U+0000 NULL
     }
 
-    /**
-     * Validates if a string is a valid HTML tag.
-     *
-     * @param string $content The string to validate.
-     *
-     * @return bool `True` if the string is a valid HTML tag, `false` otherwise.
-     */
-    public static function isValidTag(string $content): bool
+    public static function cleanXSS(string $content): string|array
     {
-        if ($content === '') {
-            return false;
-        }
+        $antiXss = new AntiXSS();
 
-        $dom = new DOMDocument();
-
-        libxml_use_internal_errors(true);
-
-        match (str_contains($content, '<svg')) {
-            false => $dom->loadHTML($content),
-            true => $dom->loadXML($content, LIBXML_NOBLANKS),
-        };
-
-        $errors = libxml_get_errors();
-
-        libxml_clear_errors();
-
-        return $errors === [];
+        return $antiXss->xss_clean($content);
     }
 }

--- a/tests/Attribute/Custom/HasContentTest.php
+++ b/tests/Attribute/Custom/HasContentTest.php
@@ -5,11 +5,26 @@ declare(strict_types=1);
 namespace PHPForge\Html\Tests\Attribute\Custom;
 
 use PHPForge\Html\Attribute\Custom\HasContent;
-use PHPForge\Html\Span;
 use PHPUnit\Framework\TestCase;
 
 final class HasContentTest extends TestCase
 {
+    public function testContentWithXSS(): void
+    {
+        $instance = new class() {
+            use HasContent;
+
+            public function getContent(): string
+            {
+                return $this->content;
+            }
+        };
+
+        $instance = $instance->content("<script>alert('Hack');</script>");
+
+        $this->assertEmpty($instance->getContent());
+    }
+
     public function testGetContent(): void
     {
         $instance = new class() {
@@ -21,17 +36,6 @@ final class HasContentTest extends TestCase
         $instance = $instance->content('foo');
 
         $this->assertSame('foo', $instance->getContent());
-    }
-
-    public function testEncode(): void
-    {
-        $instance = new class() {
-            use HasContent;
-        };
-
-        $instance = $instance->content(Span::widget(), 'foo && bar');
-
-        $this->assertSame('<span></span>foo &amp;&amp; bar', $instance->getContent());
     }
 
     public function testImmutablity(): void

--- a/tests/Attribute/Custom/HasLabelTest.php
+++ b/tests/Attribute/Custom/HasLabelTest.php
@@ -93,7 +93,23 @@ final class HasLabelTest extends TestCase
 
         $instance = $instance->labelContent('foo && bar', Span::widget()->content('foo && bar'));
 
-        $this->assertSame('foo &amp;&amp; bar<span>foo &amp;&amp; bar</span>', $instance->getLabelContent());
+        $this->assertSame('foo && bar<span>foo && bar</span>', $instance->getLabelContent());
+    }
+
+    public function testLabelContentWithXSS(): void
+    {
+        $instance = new class() {
+            use HasLabel;
+
+            public function getLabelContent(): string
+            {
+                return $this->labelContent;
+            }
+        };
+
+        $instance = $instance->labelContent("<script>alert('Hack');</script>", Span::widget()->content('foo && bar'));
+
+        $this->assertSame("<span>foo && bar</span>", $instance->getLabelContent());
     }
 
     public function testNotLabel(): void

--- a/tests/Attribute/Custom/HasPrefixAndSuffixItemsTest.php
+++ b/tests/Attribute/Custom/HasPrefixAndSuffixItemsTest.php
@@ -33,7 +33,23 @@ final class HasPrefixAndSuffixItemsTest extends TestCase
 
         $instance = $instance->prefixItems(Span::widget(), 'foo && bar');
 
-        $this->assertSame('<span></span>foo &amp;&amp; bar', $instance->getPrefixItems());
+        $this->assertSame('<span></span>foo && bar', $instance->getPrefixItems());
+    }
+
+    public function testPrefixItemsWithXSS(): void
+    {
+        $instance = new class() {
+            use HasPrefixAndSuffixItems;
+
+            public function getPrefixItems(): string
+            {
+                return $this->prefixItems;
+            }
+        };
+
+        $instance = $instance->prefixItems(Span::widget(), "<script>alert('Hack');</script>");
+
+        $this->assertSame("<span></span>", $instance->getPrefixItems());
     }
 
     public function testSuffixItems(): void
@@ -49,6 +65,22 @@ final class HasPrefixAndSuffixItemsTest extends TestCase
 
         $instance = $instance->suffixItems('foo && bar', Span::widget());
 
-        $this->assertSame('foo &amp;&amp; bar<span></span>', $instance->getSuffixItems());
+        $this->assertSame('foo && bar<span></span>', $instance->getSuffixItems());
+    }
+
+    public function testSuffixItemsWithXSS(): void
+    {
+        $instance = new class() {
+            use HasPrefixAndSuffixItems;
+
+            public function getSuffixItems(): string
+            {
+                return $this->suffixItems;
+            }
+        };
+
+        $instance = $instance->suffixItems("<script>alert('Hack');</script>", Span::widget());
+
+        $this->assertSame("<span></span>", $instance->getSuffixItems());
     }
 }

--- a/tests/Attribute/Custom/HasPrefixAndSuffixTest.php
+++ b/tests/Attribute/Custom/HasPrefixAndSuffixTest.php
@@ -33,7 +33,23 @@ final class HasPrefixAndSuffixTest extends TestCase
 
         $instance = $instance->prefix(Span::widget(), 'foo && bar');
 
-        $this->assertSame('<span></span>foo &amp;&amp; bar', $instance->getPrefix());
+        $this->assertSame('<span></span>foo && bar', $instance->getPrefix());
+    }
+
+    public function testPrefixWithXSS(): void
+    {
+        $instance = new class() {
+            use HasPrefixAndSuffix;
+
+            public function getPrefix(): string
+            {
+                return $this->prefix;
+            }
+        };
+
+        $instance = $instance->prefix(Span::widget(), "<script>alert('Hack');</script>");
+
+        $this->assertSame("<span></span>", $instance->getPrefix());
     }
 
     public function testSuffix(): void
@@ -49,6 +65,22 @@ final class HasPrefixAndSuffixTest extends TestCase
 
         $instance = $instance->suffix('foo && bar', Span::widget());
 
-        $this->assertSame('foo &amp;&amp; bar<span></span>', $instance->getSuffix());
+        $this->assertSame('foo && bar<span></span>', $instance->getSuffix());
+    }
+
+    public function testSuffixWithXSS(): void
+    {
+        $instance = new class() {
+            use HasPrefixAndSuffix;
+
+            public function getSuffix(): string
+            {
+                return $this->suffix;
+            }
+        };
+
+        $instance = $instance->suffix("<script>alert('Hack');</script>", Span::widget());
+
+        $this->assertSame("<span></span>", $instance->getSuffix());
     }
 }

--- a/tests/Attribute/Custom/HasToggleTest.php
+++ b/tests/Attribute/Custom/HasToggleTest.php
@@ -99,13 +99,9 @@ final class HasToggleTest extends TestCase
             }
         };
 
-        $instance = $instance->toggleContent(
-            'foo && bar',
-            Span::widget(),
-            'id',
-        );
+        $instance = $instance->toggleContent('foo && bar', Span::widget(), 'id');
 
-        $this->assertSame('foo &amp;&amp; bar<span></span>id', $instance->getToggleContent());
+        $this->assertSame('foo && bar<span></span>id', $instance->getToggleContent());
     }
 
     public function testToggleSvg(): void
@@ -143,6 +139,22 @@ final class HasToggleTest extends TestCase
         };
 
         $instance = $instance->toggleSvg('<svg>x</svg>');
+
+        $this->assertSame('<svg>x</svg>', $instance->getToggleSvg());
+    }
+
+    public function testToggleSvgWithXSS(): void
+    {
+        $instance = new class() {
+            use HasToggle;
+
+            public function getToggleSvg(): string
+            {
+                return $this->toggleSvg;
+            }
+        };
+
+        $instance = $instance->toggleSvg('<svg><script>alert("xss")</script>x</svg>');
 
         $this->assertSame('<svg>x</svg>', $instance->getToggleSvg());
     }

--- a/tests/Helper/EncodeTest.php
+++ b/tests/Helper/EncodeTest.php
@@ -22,30 +22,6 @@ final class EncodeTest extends TestCase
         $this->assertSame($expected, Encode::content($value, $doubleEncode));
     }
 
-    public function testIsInvalidTag(): void
-    {
-        $this->assertFalse(Encode::isValidTag(''));
-        $this->assertFalse(Encode::isValidTag('<div'));
-    }
-
-    public function testIsValidSvg(): void
-    {
-        $this->assertTrue(
-            Encode::isValidTag(
-                <<<HTML
-                <svg class='w-6 h-6' aria-hidden='true' fill='currentColor' viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'>
-                <path fill-rule='evenodd' d='M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z' clip-rule='evenodd'></path>
-                </svg>
-                HTML
-            )
-        );
-    }
-
-    public function testIsInvalidSvg(): void
-    {
-        $this->assertFalse(Encode::isValidTag('<svg'));
-    }
-
     /**
      * @dataProvider PHPForge\Html\Tests\Provider\EncodeProvider::encodeValue
      *

--- a/tests/Label/RenderTest.php
+++ b/tests/Label/RenderTest.php
@@ -14,7 +14,12 @@ final class RenderTest extends TestCase
 {
     public function testContent(): void
     {
-        $this->assertSame('<label>Sam &amp; Dark</label>', Label::widget()->content('Sam & Dark')->render());
+        $this->assertSame('<label>Sam & Dark</label>', Label::widget()->content('Sam & Dark')->render());
+    }
+
+    public function testContentWithXSS(): void
+    {
+        $this->assertSame('<label></label>', Label::widget()->content("<script>alert('Hack');</script>")->render());
     }
 
     public function testElement(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
