### PR TITLE
Better naming method `notToggle()`.

### DIFF
--- a/src/Attribute/Custom/HasToggle.php
+++ b/src/Attribute/Custom/HasToggle.php
@@ -22,12 +22,12 @@ trait HasToggle
     private string $toggleType = 'button';
 
     /**
-     * Returns a new instance, specifying disabled toggle.
+     * Returns a new instance, specifying if the toggle button should be rendered.
      */
-    public function notToggle(): static
+    public function toggle(bool $value): static
     {
         $new = clone $this;
-        $new->toggle = false;
+        $new->toggle = $value;
 
         return $new;
     }

--- a/tests/Attribute/Custom/HasToggleTest.php
+++ b/tests/Attribute/Custom/HasToggleTest.php
@@ -18,7 +18,7 @@ final class HasToggleTest extends TestCase
             use HasToggle;
         };
 
-        $this->assertNotSame($instance, $instance->notToggle());
+        $this->assertNotSame($instance, $instance->toggle(true));
         $this->assertNotSame($instance, $instance->toggleAttributes([]));
         $this->assertNotSame($instance, $instance->toggleClass(''));
         $this->assertNotSame($instance, $instance->toggleContent(''));
@@ -29,7 +29,7 @@ final class HasToggleTest extends TestCase
         $this->assertNotSame($instance, $instance->toggletype(''));
     }
 
-    public function testNotToggle(): void
+    public function testToggle(): void
     {
         $instance = new class() {
             use HasToggle;
@@ -41,7 +41,7 @@ final class HasToggleTest extends TestCase
         };
 
         $this->assertTrue($instance->getToggle());
-        $this->assertFalse($instance->notToggle()->getToggle());
+        $this->assertFalse($instance->toggle(false)->getToggle());
     }
 
     public function testToggleAttributes(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
