### PR TITLE
Add `container` methods for `prefix` and `suffix`.

### DIFF
--- a/src/Attribute/Custom/HasPrefixAndSuffix.php
+++ b/src/Attribute/Custom/HasPrefixAndSuffix.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PHPForge\Html\Attribute\Custom;
 
+use InvalidArgumentException;
+use PHPForge\Html\Helper\CssClass;
 use PHPForge\Html\Helper\Encode;
 use PHPForge\Widget\ElementInterface;
 
@@ -12,8 +14,14 @@ use PHPForge\Widget\ElementInterface;
  */
 trait HasPrefixAndSuffix
 {
+    protected bool $prefixContainer = false;
+    protected array $prefixContainerAttributes = [];
+    protected string $prefixContainerTag = 'div';
     protected string $prefix = '';
     protected string $suffix = '';
+    protected bool $suffixContainer = false;
+    protected array $suffixContainerAttributes = [];
+    protected string $suffixContainerTag = 'div';
 
     /**
      * Set the `HTML` prefix content.
@@ -31,6 +39,72 @@ trait HasPrefixAndSuffix
     }
 
     /**
+     * Enable or disable the prefix container.
+     *
+     * @param bool $value The prefix container value.
+     *
+     * @return static A new instance of the current class with the specified prefix container value.
+     */
+    public function prefixContainer(bool $value): static
+    {
+        $new = clone $this;
+        $new->prefixContainer = $value;
+
+        return $new;
+    }
+
+    /**
+     * Set the `HTML` attributes for the prefix container.
+     *
+     * @param array $values Attribute values indexed by attribute names.
+     *
+     * @return static A new instance of the current class with the specified prefix container attributes.
+     */
+    public function prefixContainerAttributes(array $values): static
+    {
+        $new = clone $this;
+        $new->prefixContainerAttributes = $values;
+
+        return $new;
+    }
+
+    /**
+     * Set the `CSS` class for the prefix container.
+     *
+     * @param string $value The CSS class name.
+     *
+     * @return static A new instance of the current class with the specified prefix container class.
+     */
+    public function prefixContainerClass(string $value): static
+    {
+        $new = clone $this;
+        CssClass::add($new->prefixContainerAttributes, $value);
+
+        return $new;
+    }
+
+    /**
+     * Set the prefix container tag name.
+     *
+     * @param string $value The tag name for the prefix container element.
+     *
+     * @return static A new instance of the current class with the specified prefix container tag.
+     *
+     * @throws InvalidArgumentException If the prefix container tag is an empty string.
+     */
+    public function prefixContainerTag(string $value): static
+    {
+        if ($value === '') {
+            throw new InvalidArgumentException('The prefix container tag must be a non-empty string.');
+        }
+
+        $new = clone $this;
+        $new->prefixContainerTag = $value;
+
+        return $new;
+    }
+
+    /**
      * Set the `HTML` suffix content.
      *
      * @param string|ElementInterface ...$values The `HTML` suffix content.
@@ -41,6 +115,72 @@ trait HasPrefixAndSuffix
     {
         $new = clone $this;
         $new->suffix = Encode::create()->santizeXSS(...$values);
+
+        return $new;
+    }
+
+    /**
+     * Enable or disable the suffix container.
+     *
+     * @param bool $value The suffix container value.
+     *
+     * @return static A new instance of the current class with the specified suffix container value.
+     */
+    public function suffixContainer(bool $value): static
+    {
+        $new = clone $this;
+        $new->suffixContainer = $value;
+
+        return $new;
+    }
+
+    /**
+     * Set the `HTML` attributes for the suffix container.
+     *
+     * @param array $values Attribute values indexed by attribute names.
+     *
+     * @return static A new instance of the current class with the specified suffix container attributes.
+     */
+    public function suffixContainerAttributes(array $values): static
+    {
+        $new = clone $this;
+        $new->suffixContainerAttributes = $values;
+
+        return $new;
+    }
+
+    /**
+     * Set the `CSS` class for the suffix container.
+     *
+     * @param string $value The CSS class name.
+     *
+     * @return static A new instance of the current class with the specified suffix container class.
+     */
+    public function suffixContainerClass(string $value): static
+    {
+        $new = clone $this;
+        CssClass::add($new->suffixContainerAttributes, $value);
+
+        return $new;
+    }
+
+    /**
+     * Set the suffix container tag name.
+     *
+     * @param string $value The tag name for the suffix container element.
+     *
+     * @return static A new instance of the current class with the specified suffix container tag.
+     *
+     * @throws InvalidArgumentException If the suffix container tag is an empty string.
+     */
+    public function suffixContainerTag(string $value): static
+    {
+        if ($value === '') {
+            throw new InvalidArgumentException('The suffix container tag must be a non-empty string.');
+        }
+
+        $new = clone $this;
+        $new->suffixContainerTag = $value;
 
         return $new;
     }

--- a/tests/Attribute/Custom/HasContainerTest.php
+++ b/tests/Attribute/Custom/HasContainerTest.php
@@ -35,7 +35,7 @@ final class HasContainerTest extends TestCase
         $this->assertSame('foo bar', $instance->getContainerClass());
     }
 
-    public function testException(): void
+    public function testContainerTagException(): void
     {
         $instance = new class() {
             use HasContainer;

--- a/tests/Attribute/Custom/HasPrefixAndSuffixTest.php
+++ b/tests/Attribute/Custom/HasPrefixAndSuffixTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PHPForge\Html\Tests\Attribute\Custom;
 
+use InvalidArgumentException;
 use PHPForge\Html\Attribute\Custom\HasPrefixAndSuffix;
 use PHPForge\Html\Span;
 use PHPUnit\Framework\TestCase;
@@ -17,7 +18,15 @@ final class HasPrefixAndSuffixTest extends TestCase
         };
 
         $this->assertNotSame($instance, $instance->prefix(''));
+        $this->assertNotSame($instance, $instance->prefixContainer(false));
+        $this->assertNotSame($instance, $instance->prefixContainerAttributes([]));
+        $this->assertNotSame($instance, $instance->prefixContainerClass(''));
+        $this->assertNotSame($instance, $instance->prefixContainerTag('span'));
         $this->assertNotSame($instance, $instance->suffix(''));
+        $this->assertNotSame($instance, $instance->suffixContainer(false));
+        $this->assertNotSame($instance, $instance->suffixContainerAttributes([]));
+        $this->assertNotSame($instance, $instance->suffixContainerClass(''));
+        $this->assertNotSame($instance, $instance->suffixContainerTag('span'));
     }
 
     public function testPrefix(): void
@@ -34,6 +43,40 @@ final class HasPrefixAndSuffixTest extends TestCase
         $instance = $instance->prefix(Span::widget(), 'foo && bar');
 
         $this->assertSame('<span></span>foo && bar', $instance->getPrefix());
+    }
+
+    public function testPrefixContainerClass(): void
+    {
+        $instance = new class() {
+            use HasPrefixAndSuffix;
+
+            public function getPrefixContainerClass(): string
+            {
+                return $this->prefixContainerAttributes['class'] ?? '';
+            }
+        };
+
+        $this->assertEmpty($instance->getPrefixContainerClass());
+
+        $instance = $instance->prefixContainerClass('foo');
+
+        $this->assertSame('foo', $instance->getPrefixContainerClass());
+
+        $instance = $instance->prefixContainerClass('bar');
+
+        $this->assertSame('foo bar', $instance->getPrefixContainerClass());
+    }
+
+    public function testPrefixContainerTagException(): void
+    {
+        $instance = new class() {
+            use HasPrefixAndSuffix;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The prefix container tag must be a non-empty string.');
+
+        $instance->prefixContainerTag('');
     }
 
     public function testPrefixWithXSS(): void
@@ -66,6 +109,40 @@ final class HasPrefixAndSuffixTest extends TestCase
         $instance = $instance->suffix('foo && bar', Span::widget());
 
         $this->assertSame('foo && bar<span></span>', $instance->getSuffix());
+    }
+
+    public function testSuffixContainerClass(): void
+    {
+        $instance = new class() {
+            use HasPrefixAndSuffix;
+
+            public function getSuffixContainerClass(): string
+            {
+                return $this->suffixContainerAttributes['class'] ?? '';
+            }
+        };
+
+        $this->assertEmpty($instance->getSuffixContainerClass());
+
+        $instance = $instance->suffixContainerClass('foo');
+
+        $this->assertSame('foo', $instance->getSuffixContainerClass());
+
+        $instance = $instance->suffixContainerClass('bar');
+
+        $this->assertSame('foo bar', $instance->getSuffixContainerClass());
+    }
+
+    public function testSuffixContainerTagException(): void
+    {
+        $instance = new class() {
+            use HasPrefixAndSuffix;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The suffix container tag must be a non-empty string.');
+
+        $instance->suffixContainerTag('');
     }
 
     public function testSuffixWithXSS(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
