### PR TITLE
Add `prefix()`, `suffix()` in `Select::class`.

### DIFF
--- a/src/Base/AbstractSelect.php
+++ b/src/Base/AbstractSelect.php
@@ -26,6 +26,7 @@ abstract class AbstractSelect extends Element
     use Attribute\Custom\HasAttributes;
     use Attribute\Custom\HasItems;
     use Attribute\Custom\HasLabel;
+    use Attribute\Custom\HasPrefixAndSuffix;
     use Attribute\HasClass;
     use Attribute\HasId;
     use Attribute\Input\CanBeMultiple;
@@ -67,20 +68,18 @@ abstract class AbstractSelect extends Element
 
         unset($attributes['value']);
 
+        $selectTag = Tag::widget()
+            ->attributes($attributes)
+            ->content($items)
+            ->prefix($this->prefix)
+            ->suffix($this->suffix)
+            ->tagName('select');
+
         return match ($this->labelContent) {
-            '' => Tag::widget()
-                ->attributes($attributes)
-                ->content($items)
-                ->tagName('select')
-                ->render(),
+            '' => $selectTag->render(),
             default => Label::widget()
                 ->attributes($this->labelAttributes)
-                ->content(
-                    $this->labelContent,
-                    PHP_EOL,
-                    Tag::widget()->attributes($attributes)->content($items)->tagName('select'),
-                    PHP_EOL,
-                )
+                ->content($this->labelContent, PHP_EOL, $selectTag, PHP_EOL)
                 ->render(),
         };
     }

--- a/tests/Select/RenderTest.php
+++ b/tests/Select/RenderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PHPForge\Html\Tests\Select;
 
 use PHPForge\Html\Select;
+use PHPForge\Html\Span;
 use PHPForge\Support\Assert;
 use PHPUnit\Framework\TestCase;
 
@@ -186,6 +187,23 @@ final class RenderTest extends TestCase
         );
     }
 
+    public function testPrefix(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <span>test-prefix</span>
+            <select>
+            <option>Select an option</option>
+            <option value="1">Moscu</option>
+            <option value="2">San Petersburgo</option>
+            <option value="3">Novosibirsk</option>
+            <option value="4">Ekaterinburgo</option>
+            </select>
+            HTML,
+            Select::widget()->items($this->cities)->prefix(Span::widget()->content('test-prefix'))->render(),
+        );
+    }
+
     public function testPrompt(): void
     {
         Assert::equalsWithoutLE(
@@ -212,6 +230,23 @@ final class RenderTest extends TestCase
             </select>
             HTML,
             Select::widget()->items($this->cities)->prompt('Select City Birth', '0')->render(),
+        );
+    }
+
+    public function testSuffix(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <select>
+            <option>Select an option</option>
+            <option value="1">Moscu</option>
+            <option value="2">San Petersburgo</option>
+            <option value="3">Novosibirsk</option>
+            <option value="4">Ekaterinburgo</option>
+            </select>
+            <span>test-suffix</span>
+            HTML,
+            Select::widget()->items($this->cities)->suffix(Span::widget()->content('test-suffix'))->render(),
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
