### PR TITLE
Add `enctype()` method to `Form::class`.

### DIFF
--- a/src/Base/AbstractForm.php
+++ b/src/Base/AbstractForm.php
@@ -31,6 +31,7 @@ abstract class AbstractForm extends Block
     use Attribute\Input\HasName;
     use Attribute\Tag\CanBeNoValidate;
     use Attribute\Tag\HasAction;
+    use Attribute\Tag\HasEnctype;
     use Attribute\Tag\HasMethod;
 
     protected array $attributes = [];

--- a/tests/Form/RenderTest.php
+++ b/tests/Form/RenderTest.php
@@ -111,6 +111,17 @@ final class RenderTest extends TestCase
         );
     }
 
+    public function testEnctype(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <form enctype="multipart/form-data">
+            </form>
+            HTML,
+            Form::widget()->enctype('multipart/form-data')->render(),
+        );
+    }
+
     public function testEnd(): void
     {
         Form::widget()->begin();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
