### PR TITLE
Split `HasLink::class` and `HasLinkAttribute::class`.

### DIFF
--- a/src/Attribute/Component/HasLink.php
+++ b/src/Attribute/Component/HasLink.php
@@ -4,17 +4,12 @@ declare(strict_types=1);
 
 namespace PHPForge\Html\Attribute\Component;
 
-use PHPForge\Html\Helper\CssClass;
-
-use function array_merge;
-
 /**
- * Is used by widgets that implement the link methods.
+ * Is used by widgets that implement the link method.
  */
 trait HasLink
 {
     protected string $link = '';
-    protected array $linkAttributes = [];
 
     /**
      * @return string The link of the menu item.
@@ -22,14 +17,6 @@ trait HasLink
     public function getLink(): string
     {
         return $this->link;
-    }
-
-    /**
-     * @return array The `HTML` attributes of the href of the menu item.
-     */
-    public function getLinkAttributes(): array
-    {
-        return $this->linkAttributes;
     }
 
     /**
@@ -43,36 +30,6 @@ trait HasLink
     {
         $new = clone $this;
         $new->link = $value;
-
-        return $new;
-    }
-
-    /**
-     * Set the `HTML` attributes for the link tag.
-     *
-     * @param array $values Attribute values indexed by attribute names.
-     *
-     * @return static A new instance of the current class with the specified link attributes.
-     */
-    public function linkAttributes(array $values): static
-    {
-        $new = clone $this;
-        $new->linkAttributes = array_merge($this->linkAttributes, $values);
-
-        return $new;
-    }
-
-    /**
-     * Set the `CSS` class for the link tag.
-     *
-     * @param string $value The `CSS` class for the link tag.
-     *
-     * @return static A new instance of the current class with the specified link class.
-     */
-    public function linkClass(string $value): static
-    {
-        $new = clone $this;
-        CssClass::add($new->linkAttributes, $value);
 
         return $new;
     }

--- a/src/Attribute/Component/HasLinkAttributes.php
+++ b/src/Attribute/Component/HasLinkAttributes.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPForge\Html\Attribute\Component;
+
+use PHPForge\Html\Helper\CssClass;
+
+use function array_merge;
+
+/**
+ * Is used by widgets that implement the link attributes methods.
+ */
+trait HasLinkAttributes
+{
+    protected array $linkAttributes = [];
+
+    /**
+     * @return array The `HTML` attributes of the href of the menu item.
+     */
+    public function getLinkAttributes(): array
+    {
+        return $this->linkAttributes;
+    }
+
+    /**
+     * Set the `HTML` attributes for the link tag.
+     *
+     * @param array $values Attribute values indexed by attribute names.
+     *
+     * @return static A new instance of the current class with the specified link attributes.
+     */
+    public function linkAttributes(array $values): static
+    {
+        $new = clone $this;
+        $new->linkAttributes = array_merge($this->linkAttributes, $values);
+
+        return $new;
+    }
+
+    /**
+     * Set the `CSS` class for the link tag.
+     *
+     * @param string $value The `CSS` class for the link tag.
+     *
+     * @return static A new instance of the current class with the specified link class.
+     */
+    public function linkClass(string $value): static
+    {
+        $new = clone $this;
+        CssClass::add($new->linkAttributes, $value);
+
+        return $new;
+    }
+}

--- a/tests/Attribute/Component/HasLinkAttributesTest.php
+++ b/tests/Attribute/Component/HasLinkAttributesTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPForge\Html\Tests\Attribute\Component;
+
+use PHPForge\Html\Attribute\Component\HasLinkAttributes;
+use PHPUnit\Framework\TestCase;
+
+final class HasLinkAttributesTest extends TestCase
+{
+    public function testAttributes(): void
+    {
+        $instance = new class() {
+            use HasLinkAttributes;
+
+            public function getLinkAttributes(): array
+            {
+                return $this->linkAttributes;
+            }
+        };
+
+        $instance = $instance->linkAttributes(['class' => 'foo']);
+        $instance = $instance->linkAttributes(['disabled' => true]);
+
+        $this->assertSame(['class' => 'foo', 'disabled' => true], $instance->getLinkAttributes());
+    }
+
+    public function testClass(): void
+    {
+        $instance = new class() {
+            use HasLinkAttributes;
+
+            public function getLinkAttributes(): array
+            {
+                return $this->linkAttributes;
+            }
+        };
+
+        $this->assertSame(['class' => 'test-class'], $instance->linkClass('test-class')->getLinkAttributes());
+    }
+
+    public function testGetLinkAttributes(): void
+    {
+        $instance = new class() {
+            use HasLinkAttributes;
+        };
+
+        $this->assertSame(['class' => 'test-class'], $instance->linkAttributes(['class' => 'test-class'])->getLinkAttributes());
+    }
+
+    public function testImmutablity(): void
+    {
+        $instance = new class() {
+            use HasLinkAttributes;
+        };
+
+        $this->assertNotSame($instance, $instance->linkAttributes([]));
+        $this->assertNotSame($instance, $instance->linkClass(''));
+    }
+}

--- a/tests/Attribute/Component/HasLinkTest.php
+++ b/tests/Attribute/Component/HasLinkTest.php
@@ -9,37 +9,6 @@ use PHPUnit\Framework\TestCase;
 
 final class HasLinkTest extends TestCase
 {
-    public function testAttributes(): void
-    {
-        $instance = new class() {
-            use HasLink;
-
-            public function getLinkAttributes(): array
-            {
-                return $this->linkAttributes;
-            }
-        };
-
-        $instance = $instance->linkAttributes(['class' => 'foo']);
-        $instance = $instance->linkAttributes(['disabled' => true]);
-
-        $this->assertSame(['class' => 'foo', 'disabled' => true], $instance->getLinkAttributes());
-    }
-
-    public function testClass(): void
-    {
-        $instance = new class() {
-            use HasLink;
-
-            public function getLinkAttributes(): array
-            {
-                return $this->linkAttributes;
-            }
-        };
-
-        $this->assertSame(['class' => 'test-class'], $instance->linkClass('test-class')->getLinkAttributes());
-    }
-
     public function testGetLink(): void
     {
         $instance = new class() {
@@ -49,15 +18,6 @@ final class HasLinkTest extends TestCase
         $this->assertSame('test-link', $instance->link('test-link')->getLink());
     }
 
-    public function testGetLinkAttributes(): void
-    {
-        $instance = new class() {
-            use HasLink;
-        };
-
-        $this->assertSame(['class' => 'test-class'], $instance->linkAttributes(['class' => 'test-class'])->getLinkAttributes());
-    }
-
     public function testImmutablity(): void
     {
         $instance = new class() {
@@ -65,7 +25,5 @@ final class HasLinkTest extends TestCase
         };
 
         $this->assertNotSame($instance, $instance->link(''));
-        $this->assertNotSame($instance, $instance->linkAttributes([]));
-        $this->assertNotSame($instance, $instance->linkClass(''));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
