### PR TITLE
Add `getListItemAttributes()` method to `HasListItem::class`.

### DIFF
--- a/src/Attribute/Component/HasListItem.php
+++ b/src/Attribute/Component/HasListItem.php
@@ -14,6 +14,16 @@ trait HasListItem
     protected array $listItemAttributes = [];
 
     /**
+     * Get the `HTML` attributes for tag `<li>`.
+     *
+     * @return array Attribute values indexed by attribute names.
+     */
+    public function getListItemAttributes(): array
+    {
+        return $this->listItemAttributes;
+    }
+
+    /**
      * Set the `HTML` attributes for tag `<li>`.
      *
      * @param array $values Attribute values indexed by attribute names.

--- a/tests/Attribute/Component/HasListItemTest.php
+++ b/tests/Attribute/Component/HasListItemTest.php
@@ -31,6 +31,19 @@ final class HasListItemTest extends TestCase
         $this->assertSame('foo bar', $instance->getListItemClass());
     }
 
+    public function testGetListItemAttributes(): void
+    {
+        $instance = new class() {
+            use HasListItem;
+        };
+
+        $this->assertEmpty($instance->getListItemAttributes());
+
+        $instance = $instance->listItemAttributes(['foo' => 'bar']);
+
+        $this->assertSame(['foo' => 'bar'], $instance->getListItemAttributes());
+    }
+
     public function testImmutablity(): void
     {
         $instance = new class() {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
