### PR TITLE
Add `ariaLabel()` method in `AbstractA::class`, `AbstractSelect::class` widget.

### DIFF
--- a/src/Base/AbstractA.php
+++ b/src/Base/AbstractA.php
@@ -12,6 +12,7 @@ use PHPForge\Html\Attribute;
 abstract class AbstractA extends AbstractElement
 {
     use Attribute\Aria\HasAriaDisabled;
+    use Attribute\Aria\HasAriaLabel;
     use Attribute\Aria\HasRole;
     use Attribute\CanBeAutofocus;
     use Attribute\CanBeHidden;

--- a/src/Base/AbstractSelect.php
+++ b/src/Base/AbstractSelect.php
@@ -23,11 +23,13 @@ use function is_object;
  */
 abstract class AbstractSelect extends Element
 {
+    use Attribute\Aria\HasAriaLabel;
     use Attribute\Custom\HasAttributes;
     use Attribute\Custom\HasLabel;
     use Attribute\Custom\HasPrefixAndSuffix;
     use Attribute\HasClass;
     use Attribute\HasId;
+    use Attribute\HasTabindex;
     use Attribute\Input\CanBeMultiple;
     use Attribute\Input\HasName;
     use Attribute\Input\HasSize;

--- a/tests/A/RenderTest.php
+++ b/tests/A/RenderTest.php
@@ -19,6 +19,11 @@ final class RenderTest extends TestCase
         $this->assertSame('<a aria-disabled="true"></a>', A::widget()->ariaDisabled('true')->render());
     }
 
+    public function testAriaLabel(): void
+    {
+        $this->assertSame('<a aria-label="test-aria-label"></a>', A::widget()->ariaLabel('test-aria-label')->render());
+    }
+
     public function testAttributes(): void
     {
         $this->assertSame('<a class="test-class"></a>', A::widget()->attributes(['class' => 'test-class'])->render());

--- a/tests/Select/RenderTest.php
+++ b/tests/Select/RenderTest.php
@@ -38,6 +38,19 @@ final class RenderTest extends TestCase
         '2' => ['label' => 'Chile'],
     ];
 
+    public function testAriaLabel(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <select aria-label="test-aria-label">
+            <option>Select an option</option>
+            <option value="1">Moscu</option>
+            </select>
+            HTML,
+            Select::widget()->items([1 => 'Moscu'])->ariaLabel('test-aria-label')->render(),
+        );
+    }
+
     public function testElement(): void
     {
         Assert::equalsWithoutLE(
@@ -247,6 +260,19 @@ final class RenderTest extends TestCase
             <span>test-suffix</span>
             HTML,
             Select::widget()->items($this->cities)->suffix(Span::widget()->content('test-suffix'))->render(),
+        );
+    }
+
+    public function testTabIndex(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <select tabindex="1">
+            <option>Select an option</option>
+            <option value="1">Moscu</option>
+            </select>
+            HTML,
+            Select::widget()->items([1 => 'Moscu'])->tabIndex(1)->render(),
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
