### PR TITLE
Add `ariaControls()`, `ariaExpanded()` in `AbstractA::class` widget.

### DIFF
--- a/src/Base/AbstractA.php
+++ b/src/Base/AbstractA.php
@@ -13,6 +13,8 @@ abstract class AbstractA extends AbstractElement
 {
     use Attribute\Aria\HasAriaDisabled;
     use Attribute\Aria\HasAriaLabel;
+    use Attribute\Aria\HasAriaControls;
+    use Attribute\Aria\HasAriaExpanded;
     use Attribute\Aria\HasRole;
     use Attribute\CanBeAutofocus;
     use Attribute\CanBeHidden;

--- a/src/Base/AbstractA.php
+++ b/src/Base/AbstractA.php
@@ -11,10 +11,10 @@ use PHPForge\Html\Attribute;
  */
 abstract class AbstractA extends AbstractElement
 {
-    use Attribute\Aria\HasAriaDisabled;
-    use Attribute\Aria\HasAriaLabel;
     use Attribute\Aria\HasAriaControls;
+    use Attribute\Aria\HasAriaDisabled;
     use Attribute\Aria\HasAriaExpanded;
+    use Attribute\Aria\HasAriaLabel;
     use Attribute\Aria\HasRole;
     use Attribute\CanBeAutofocus;
     use Attribute\CanBeHidden;

--- a/tests/A/RenderTest.php
+++ b/tests/A/RenderTest.php
@@ -19,6 +19,16 @@ final class RenderTest extends TestCase
         $this->assertSame('<a aria-disabled="true"></a>', A::widget()->ariaDisabled('true')->render());
     }
 
+    public function testAriaControls(): void
+    {
+        $this->assertSame('<a aria-controls="test-aria-controls"></a>', A::widget()->ariaControls('test-aria-controls')->render());
+    }
+
+    public function testAriaExpanded(): void
+    {
+        $this->assertSame('<a aria-expanded="true"></a>', A::widget()->ariaExpanded('true')->render());
+    }
+
     public function testAriaLabel(): void
     {
         $this->assertSame('<a aria-label="test-aria-label"></a>', A::widget()->ariaLabel('test-aria-label')->render());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
