### PR TITLE
Add `autofocus` in `AbstractSelect::class` Widget.

### DIFF
--- a/src/Base/AbstractSelect.php
+++ b/src/Base/AbstractSelect.php
@@ -24,6 +24,7 @@ use function is_object;
 abstract class AbstractSelect extends Element
 {
     use Attribute\Aria\HasAriaLabel;
+    use Attribute\CanBeAutofocus;
     use Attribute\Custom\HasAttributes;
     use Attribute\Custom\HasLabel;
     use Attribute\Custom\HasPrefixAndSuffix;

--- a/tests/Select/RenderTest.php
+++ b/tests/Select/RenderTest.php
@@ -51,6 +51,19 @@ final class RenderTest extends TestCase
         );
     }
 
+    public function testAutofocus(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <select autofocus>
+            <option>Select an option</option>
+            <option value="1">Moscu</option>
+            </select>
+            HTML,
+            Select::widget()->items([1 => 'Moscu'])->autofocus()->render(),
+        );
+    }
+
     public function testElement(): void
     {
         Assert::equalsWithoutLE(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
