### PR TITLE
Add `uncheckName()` method to AbstractInputChoice.

### DIFF
--- a/src/Attribute/Custom/HasUnchecked.php
+++ b/src/Attribute/Custom/HasUnchecked.php
@@ -49,6 +49,21 @@ trait HasUnchecked
     }
 
     /**
+     * Set the `HTML` id for the unchecked element.
+     *
+     * @param string $value The name of the unchecked element.
+     *
+     * @return static A new instance of the current class with the specified unchecked name.
+     */
+    public function uncheckName(string $value): static
+    {
+        $new = clone $this;
+        $new->uncheckAttributes['name'] = $value;
+
+        return $new;
+    }
+
+    /**
      * set the value content attribute gives the default value of the unchecked field.
      *
      * @param mixed $value The value of the unchecked field.

--- a/src/Input/Base/AbstractInputChoice.php
+++ b/src/Input/Base/AbstractInputChoice.php
@@ -79,6 +79,7 @@ abstract class AbstractInputChoice extends Element implements
         /** @var string $id */
         $id = $attributes['id'] ?? $this->generateId("$type-");
         $labelFor = $this->labelFor ?? $id;
+        $uncheckName = '';
 
         if ($this->ariaDescribedBy === true) {
             $attributes['aria-describedby'] = "$id-help";
@@ -93,6 +94,10 @@ abstract class AbstractInputChoice extends Element implements
 
         unset($attributes['id'], $attributes['type'], $attributes['value']);
 
+        if (array_key_exists('name', $attributes) && is_string($attributes['name'])) {
+            $uncheckName = $attributes['name'];
+        }
+
         $tag = Tag::widget()->attributes($attributes)->id($id)->tagName('input')->type($type)->value($value)->render();
 
         if ($this->enclosedByLabel) {
@@ -101,7 +106,7 @@ abstract class AbstractInputChoice extends Element implements
             $labelTag = $this->renderLabelTag($labelFor);
         }
 
-        $choiceTag = $this->prepareTemplate($tag, $labelTag);
+        $choiceTag = $this->uncheckName($uncheckName)->prepareTemplate($tag, $labelTag);
 
         return $this->renderContainerTag(null, $choiceTag);
     }

--- a/tests/Attribute/Custom/HasUnchekedTest.php
+++ b/tests/Attribute/Custom/HasUnchekedTest.php
@@ -39,17 +39,17 @@ final class HasUnchekedTest extends TestCase
 
         $this->assertEmpty($instance->getClass());
 
-        $instance = $instance->uncheckClass('test-class');
+        $instance = $instance->uncheckClass('class');
 
-        $this->assertSame('test-class', $instance->getClass());
+        $this->assertSame('class', $instance->getClass());
 
-        $instance = $instance->uncheckClass('test-class-1');
+        $instance = $instance->uncheckClass('class-1');
 
-        $this->assertSame('test-class test-class-1', $instance->getClass());
+        $this->assertSame('class class-1', $instance->getClass());
 
-        $instance = $instance->uncheckClass('test-override-class', true);
+        $instance = $instance->uncheckClass('override-class', true);
 
-        $this->assertSame('test-override-class', $instance->getClass());
+        $this->assertSame('override-class', $instance->getClass());
     }
 
     public function testImmutability(): void
@@ -60,6 +60,7 @@ final class HasUnchekedTest extends TestCase
 
         $this->assertNotSame($instance, $instance->uncheckAttributes([]));
         $this->assertNotSame($instance, $instance->uncheckClass(''));
+        $this->assertNotSame($instance, $instance->uncheckName(''));
         $this->assertNotSame($instance, $instance->uncheckValue(null));
     }
 }

--- a/tests/Input/Checkbox/RenderTest.php
+++ b/tests/Input/Checkbox/RenderTest.php
@@ -630,14 +630,14 @@ final class RenderTest extends TestCase
         );
     }
 
-    public function testUnchecked(): void
+    public function testUncheckValue(): void
     {
         Assert::equalsWithoutLE(
             <<<HTML
-            <input type="hidden" value="0">
-            <input id="checkbox-6582f2d099e8b" type="checkbox" value="1">
+            <input name="name" type="hidden" value="0">
+            <input id="checkbox-6582f2d099e8b" name="name" type="checkbox" value="1">
             HTML,
-            Checkbox::widget()->id('checkbox-6582f2d099e8b')->uncheckValue('0')->value(1)->render()
+            Checkbox::widget()->id('checkbox-6582f2d099e8b')->name('name')->uncheckValue('0')->value(1)->render()
         );
     }
 

--- a/tests/Input/Radio/RenderTest.php
+++ b/tests/Input/Radio/RenderTest.php
@@ -607,14 +607,14 @@ final class RenderTest extends TestCase
         );
     }
 
-    public function testUnchecked(): void
+    public function testUncheckValue(): void
     {
         Assert::equalsWithoutLE(
             <<<HTML
-            <input type="hidden" value="0">
-            <input id="radio-6582f2d099e8b" type="radio" value="1">
+            <input name="name" type="hidden" value="0">
+            <input id="radio-6582f2d099e8b" name="name" type="radio" value="1">
             HTML,
-            Radio::widget()->id('radio-6582f2d099e8b')->uncheckValue('0')->value(1)->render()
+            Radio::widget()->id('radio-6582f2d099e8b')->name('name')->uncheckValue('0')->value(1)->render()
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
