### PR TITLE
Remove Contract\ValueInterface from AbstractChoiceList and AbstractInputChoice.

### DIFF
--- a/src/Input/Base/AbstractChoiceList.php
+++ b/src/Input/Base/AbstractChoiceList.php
@@ -14,8 +14,7 @@ abstract class AbstractChoiceList extends Element implements
     Contract\CheckedValueInterface,
     Contract\InputInterface,
     Contract\LabelInterface,
-    Contract\RequiredInterface,
-    Contract\ValueInterface
+    Contract\RequiredInterface
 {
     use Attribute\Aria\HasAriaDescribedBy;
     use Attribute\Aria\HasAriaLabel;

--- a/src/Input/Base/AbstractInputChoice.php
+++ b/src/Input/Base/AbstractInputChoice.php
@@ -16,8 +16,7 @@ abstract class AbstractInputChoice extends Element implements
     Contract\CheckedValueInterface,
     Contract\InputInterface,
     Contract\LabelInterface,
-    Contract\RequiredInterface,
-    Contract\ValueInterface
+    Contract\RequiredInterface
 {
     use Attribute\Aria\HasAriaDescribedBy;
     use Attribute\Aria\HasAriaLabel;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
